### PR TITLE
Refatoramento do componente collapse

### DIFF
--- a/src/components/Collapse/CollapseContent.js
+++ b/src/components/Collapse/CollapseContent.js
@@ -1,14 +1,7 @@
-import React from 'react';
+import React from "react";
 
-const CollapseContent = ({ status, content }) => {
-  if (status === 'closed') {
-    return false;
-  }
-  return (
-    <div className="content">
-      {content}
-    </div>
-  );
-};
+const CollapseContent = ({ content }) => (
+  <div className="content">{content}</div>
+);
 
 export default CollapseContent;

--- a/src/components/Collapse/CollapseHeader.js
+++ b/src/components/Collapse/CollapseHeader.js
@@ -1,23 +1,9 @@
-import React from 'react';
+import React from "react";
 
-const CollapseHeader = ({
-  title = 'sem título',
-  status,
-  handleClick,
-  id,
-}) => (
-  <div
-    className="header"
-    onClick={() => handleClick(id)}
-  >
-    <span
-      className={status === 'opened' ? 'icon opened' : 'icon'}
-    >
-      &nbsp;
-    </span>
-    <span>
-      {title}
-    </span>
+const CollapseHeader = ({ title = "sem título", opened, handleClick, id }) => (
+  <div className="header" onClick={() => handleClick(id)}>
+    <span className={opened ? "icon opened" : "icon"}>&nbsp;</span>
+    <span>{title}</span>
   </div>
 );
 

--- a/src/components/Collapse/index.js
+++ b/src/components/Collapse/index.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
-import CollapseHeader from './CollapseHeader';
-import CollapseContent from './CollapseContent';
-import './collapse.css';
+import React, { Component } from "react";
+import CollapseHeader from "./CollapseHeader";
+import CollapseContent from "./CollapseContent";
+import "./collapse.css";
 
 class Collapse extends Component {
   constructor() {
@@ -9,26 +9,27 @@ class Collapse extends Component {
     this.state = {
       data: [
         {
-          title: 'titulo de teste sobre vingadores',
-          status: 'opened',
-          content: 'Lorem laborum dolor ut reprehenderit adipisci Incidunt vel unde soluta atque laborum, corporis delectus assumenda. Explicabo deleniti commodi quis vel temporibus Dolore obcaecati corrupti asperiores dolore autem provident Facilis qui',
+          title: "titulo de teste sobre vingadores",
+          opened: true,
+          content:
+            "Lorem laborum dolor ut reprehenderit adipisci Incidunt vel unde soluta atque laborum, corporis delectus assumenda. Explicabo deleniti commodi quis vel temporibus Dolore obcaecati corrupti asperiores dolore autem provident Facilis qui"
         },
         {
-          status: 'closed',
-          content: 'Lorem laborum dolor ut reprehenderit adipisci Incidunt vel unde soluta atque laborum, corporis delectus assumenda. Explicabo deleniti commodi quis vel temporibus Dolore obcaecati corrupti asperiores dolore autem provident Facilis qui',
-        },
-      ],
+          opened: false,
+          content:
+            "Lorem laborum dolor ut reprehenderit adipisci Incidunt vel unde soluta atque laborum, corporis delectus assumenda. Explicabo deleniti commodi quis vel temporibus Dolore obcaecati corrupti asperiores dolore autem provident Facilis qui"
+        }
+      ]
     };
   }
 
-  handleClick = (id) => {
-    this.setState(prevState => {
-      const newData = prevState;
-      newData.data[id].status = newData.data[id].status === 'opened' ? 'closed' : 'opened';
-
-      return newData;
+  handleClick = id => {
+    this.setState({
+      data: this.state.data.map((ele, index) =>
+        index === id ? { ...ele, opened: !ele.opened } : ele
+      )
     });
-  }
+  };
 
   render() {
     return (
@@ -37,14 +38,11 @@ class Collapse extends Component {
           <div className="item" key={index}>
             <CollapseHeader
               title={item.title}
-              status={item.status}
+              opened={item.opened}
               id={index}
               handleClick={this.handleClick}
             />
-            <CollapseContent
-              content={item.content}
-              status={item.status}
-            />
+            {item.opened && <CollapseContent content={item.content} />}
           </div>
         ))}
       </div>


### PR DESCRIPTION
1. Substituição da prop `status` pra `opened` que recebe um valor booleano ao invés  de string.
2. Refatoramento da função `handleClick`, sem usar o prevState.
3. Mudança no render em `index.js`, para  só dar load em `<CollapseContent />` caso o elemento estiver com a propriedade opened como `true`. Evitando de ter que passar o status do componente como props.



